### PR TITLE
Fixed Maven Artifactory to work with jack

### DIFF
--- a/build/core/maven_artifact.mk
+++ b/build/core/maven_artifact.mk
@@ -50,6 +50,17 @@ $(LOCAL_PREBUILT_MODULE_FILE):
 		-DoutputDirectory=$(dir $@)
 	@echo -e ${CL_GRN}"Download:"${CL_RST}" $@"
 
+ifneq ($(filter-out disabled, $(LOCAL_JACK_ENABLED)),)
+# This is required to be defined before the LOCAL_MODULES target below gets defined, it's a NOOP registered again in
+# BUILD_PREBUILT.  This is done because BUILD_PREBUILT doesn't actually handle generating the .jack files properly and
+# only generates a target but doesn't set the LOCAL_MODULE dependent on it.
+$(call intermediates-dir-for,JAVA_LIBRARIES,$(LOCAL_MODULE),,COMMON):
+
+# This adds another step required for LOCAL_MODULE to be completed -- generating the jack file, it just so happens
+# to be built when doing a brunch, but not when doing an mmm, so this makes it work with both
+$(LOCAL_MODULE): $(call intermediates-dir-for,JAVA_LIBRARIES,$(LOCAL_MODULE),,COMMON)/classes.jack
+endif # LOCAL_JACK_ENABLED is full or partial
+
 include $(BUILD_PREBUILT)
 
 # the "fetchprebuilts" target will go through and pre-download all of the maven dependencies in the tree


### PR DESCRIPTION
Prebuilts weren't generating their .jack file when doing an mm or mmm
but would work with a brunch or full make.  This makes it so mmm/mm
will properly generate it.

Change-Id: If5ccd1b557ef124b3c57fa09b172ec11caff886e
